### PR TITLE
增加对windows平台下文件读写的兼容性

### DIFF
--- a/burplogfilter.py
+++ b/burplogfilter.py
@@ -24,15 +24,14 @@ def main():
 
     for opt,arg in options:
         if opt == "-f":
-            filename=arg
+            filename=arg.strip("'")
         if opt == "--host":
-            host=arg
+            host=arg.strip("'")
         if opt == "-h":
             showHelp()
             return
 
     blocks=scrapBlocks(filename)
-
     filteredBlocks=[]
     for block in blocks:
         if isBlockUseful(block,host) :
@@ -48,8 +47,8 @@ def scrapBlocks(filename):
         print("Try to anayze file %s"%filename)
 
     blocks=None
-    with open(filename) as file:
-        content=file.read()
+    with open(filename, 'rb') as f:
+        content=f.read()
         blocks = re.findall(r'======================================================'
             r'.*?======================================================'
             r'.*?======================================================', content, re.S)
@@ -73,11 +72,11 @@ def isBlockUseful(block,host,isFilterStaticResource=True):
     # 过滤Host
     if host:
         for line in block.split("\n"):
-            if re.match("^Host:",line):
-                if host not in line[6:]:
-                    if DEBUG:
-                        print("[DEBUG] Filter this host %s"%line[6:])
-                    return False
+            m = re.match(r"^Host:(.*)", line)
+            if m and host not in m.group(1).strip():
+                if DEBUG:
+                    print("[DEBUG] Filter this host %s" % m.group(1).strip())
+                return False
 
     # 过滤URL模式
     for line in block.split("\n"):
@@ -128,7 +127,7 @@ def showHelp():
     print("  --host keyword, --host=keyword      Host name filter")
     print("  -v                                  Show debug message")
     print("\nExamples:")
-    print("  python3 burplogfilter.py -f /tmp/burp.log --host='google.com'")
+    print("  python3 burplogfilter.py -f /tmp/burp.log --host=google.com")
     print("\n[!] to see help message of options run with '-h'")
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hello，Tony1016。
再次做了些修改，请检查：
1.发现脚本在windows下读取文件会意外中断，所以修改为二进制读取。
2.格式化了用户输入，在py2环境下输入host参数的时候如果带单引号会使获得的host参数有多余的引号。

如果在py3下测试没有问题可以考虑merge。
另外你字符串操作过多，可以考虑修改为正则过滤，会更直观一些。
